### PR TITLE
fix: update show message method to get custom error messages

### DIFF
--- a/src/modules/edc-demo/components/asset-viewer/asset-viewer.component.ts
+++ b/src/modules/edc-demo/components/asset-viewer/asset-viewer.component.ts
@@ -23,10 +23,10 @@ export class AssetViewerComponent implements OnInit {
   constructor(private assetService: AssetService,
               private notificationService: NotificationService,
               private readonly dialog: MatDialog) {
-  }
+}
 
-  private showError(error: string) {
-    this.notificationService.showError("This asset cannot be deleted");
+  private showError(error: string, errorMessage: string) {
+    this.notificationService.showError(errorMessage);
     console.error(error);
   }
 
@@ -51,27 +51,34 @@ export class AssetViewerComponent implements OnInit {
   }
 
   onDelete(asset: Asset) {
-
     const dialogData = ConfirmDialogModel.forDelete("asset", `"${asset.name}"`)
     const ref = this.dialog.open(ConfirmationDialogComponent, {maxWidth: "20%", data: dialogData});
-
-    ref.afterClosed().subscribe(res => {
-      if (res) {
-        this.assetService.removeAsset(asset.id).subscribe(() => this.fetch$.next(null),
-          err => this.showError(err),
-          () => this.notificationService.showInfo("Successfully deleted")
-        );
+  
+    ref.afterClosed().subscribe({
+      next: res => {
+        if (res) {
+          this.assetService.removeAsset(asset.id).subscribe({
+            next: () => this.fetch$.next(null),
+            error: err => this.showError(err, "This asset cannot be deleted"),
+            complete: () => this.notificationService.showInfo("Successfully deleted")
+          });
+        }
       }
     });
-
   }
-
+  
   onCreate() {
     const dialogRef = this.dialog.open(AssetEditorDialog);
-    dialogRef.afterClosed().pipe(first()).subscribe((result: { assetEntryDto?: AssetEntryDto }) => {
-      const newAsset = result?.assetEntryDto;
-      if (newAsset) {
-        this.assetService.createAsset(newAsset).subscribe(() => this.fetch$.next(null), error => this.showError(error), () => this.notificationService.showInfo("Successfully created"));
+    dialogRef.afterClosed().pipe(first()).subscribe({
+      next: (result: { assetEntryDto?: AssetEntryDto }) => {
+        const newAsset = result?.assetEntryDto;
+        if (newAsset) {
+          this.assetService.createAsset(newAsset).subscribe({
+            next: () => this.fetch$.next(null),
+            error: error => this.showError(error, "This asset cannot be created"),
+            complete: () => this.notificationService.showInfo("Successfully created")
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
## What this PR changes/adds

This PR attempts to fix the issue of having a hardcoded error message for the create and update ops. We added another argument to the **private** method `showError` where we can pass a custom message while still logging the original error message

## Why it does that

We made this change to get verbose and self-descriptive error

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #41 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
