### PR TITLE
fix: use ID in deletion dialog to prevent undefined displayed

### DIFF
--- a/src/modules/edc-demo/components/asset-viewer/asset-viewer.component.ts
+++ b/src/modules/edc-demo/components/asset-viewer/asset-viewer.component.ts
@@ -51,7 +51,7 @@ export class AssetViewerComponent implements OnInit {
   }
 
   onDelete(asset: Asset) {
-    const dialogData = ConfirmDialogModel.forDelete("asset", `"${asset.name}"`)
+    const dialogData = ConfirmDialogModel.forDelete("asset", `"${asset.id}"`)
     const ref = this.dialog.open(ConfirmationDialogComponent, {maxWidth: "20%", data: dialogData});
   
     ref.afterClosed().subscribe({


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the deletion alert dialog to display `id` instead of `name`.

## Why it does that

Name is optional and if not specified, we get **undefined** value in the dialog.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #45 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
