### PR TITLE
fix: use actual apiKey instead of dummy value

### DIFF
--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -95,7 +95,7 @@ import { EdcConnectorClient, EdcConnectorClientContext } from "@think-it-labs/ed
     {
       provide: EdcConnectorClientContext,
       useFactory: (s: AppConfigService, client: EdcConnectorClient) => {
-        return client.createContext("123456", {
+        return client.createContext(environment.apiKey, {
           default: "https://edc.connector.io/api",
           management: s.getConfig()?.managementApiUrl as string,
           protocol: "https://edc.connector.io/protocol",


### PR DESCRIPTION
## What this PR changes/adds

Ensure that the configured apiKey is used for the management api calls

\cc @edwo-dev

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #66

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
