### PR TITLE
Update transfer-history-viewer.component.html

### DIFF
--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -37,17 +37,17 @@
 
           <ng-container matColumnDef="connectorId">
               <th mat-header-cell *matHeaderCellDef scope="col">ConnectorId</th>
-              <td mat-cell *matCellDef="let item">{{item['edc:dataRequest']['edc:connectorId']}}</td>
+              <td mat-cell *matCellDef="let item">{{item['edc:connectorId']}}</td>
           </ng-container>
 
           <ng-container matColumnDef="assetId">
               <th mat-header-cell *matHeaderCellDef scope="col">AssetId</th>
-              <td mat-cell *matCellDef="let item">{{item['edc:dataRequest']['edc:assetId']}}</td>
+              <td mat-cell *matCellDef="let item">{{item['edc:assetId']}}</td>
           </ng-container>
 
           <ng-container matColumnDef="contractId">
               <th mat-header-cell *matHeaderCellDef scope="col">ContractId</th>
-              <td mat-cell *matCellDef="let item">{{item['edc:dataRequest']['edc:contractId']}}</td>
+              <td mat-cell *matCellDef="let item">{{item['edc:contractId']}}</td>
           </ng-container>
 
           <ng-container matColumnDef="action">


### PR DESCRIPTION
fix: Remove access to 'edc:dataRequest' key

## What this PR changes/adds

Removes 'edc:dataRequest' from transfer history item calls.

# Why it does that

'edc:dataRequest' object is not available anymore in transfer history response.

## Linked Issue(s)

Closes #67 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
