### PR TITLE
feat: switch `ContractDefinition` to connector client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Substitute the values as necessary:
 
 As some extra safety consider running `git udpate-index --assume-unchanged src/assets/config/app.config.json` before changing this file.
 
-## Running a frondend and a connector locally
+## Running a frondend and a connector locally (for demo purpose)
 To test the correct functionality locally you can spin up a local docker compose
 that will load the `data-dashboard` service and the `connector` one.
 First you need to change the `app.config.json` this way:
@@ -61,7 +61,7 @@ docker compose up
 
 The DataDashboard will be available at `http://localhost:8080`
 
-### Running DataDashboard from the host machine
+### Running DataDashboard from the host machine (for debugging purpose)
 To have a quicker development cycle, you can also run the DataDashboard from the
 host machine using `npm start`, sending request against the connector loaded by
 docker compose.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "~13.3.5",
         "@angular/platform-browser-dynamic": "~13.3.5",
         "@angular/router": "~13.3.5",
-        "@think-it-labs/edc-connector-client": "^0.2.0-beta-3",
+        "@think-it-labs/edc-connector-client": "^0.2.0-beta-5",
         "rxjs": "~7.8.1",
         "zone.js": "~0.11.4"
       },
@@ -2617,12 +2617,12 @@
       }
     },
     "node_modules/@think-it-labs/edc-connector-client": {
-      "version": "0.2.0-beta-3",
-      "resolved": "https://registry.npmjs.org/@think-it-labs/edc-connector-client/-/edc-connector-client-0.2.0-beta-3.tgz",
-      "integrity": "sha512-NVLQr/zGQaEWRZHxcVmxjoZgegBknTKNEqsYSS18OUW42tO97+mgpuEUyjtuvdyyQTkYAv/fPH0tIDih8i7XDw==",
+      "version": "0.2.0-beta-5",
+      "resolved": "https://registry.npmjs.org/@think-it-labs/edc-connector-client/-/edc-connector-client-0.2.0-beta-5.tgz",
+      "integrity": "sha512-5mFAqShsXggxAzW3+KXdODns6tHLU4gyKVbeJxddxDcGbX3aHeQsvBsjJOGebEymTJNp0w93I11f5VVvzTHQjw==",
       "dependencies": {
         "@think-it-labs/typed-error": "^0.3.0",
-        "jsonld": "^8.2.0"
+        "jsonld": "^8.2.1"
       },
       "engines": {
         "node": ">=18"
@@ -7178,9 +7178,9 @@
       }
     },
     "node_modules/jsonld": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.2.0.tgz",
-      "integrity": "sha512-qHUa9pn3/cdAZw26HY1Jmy9+sHOxaLrveTRWUcrSDx5apTa20bBTe+X4nzI7dlqc+M5GkwQW6RgRdqO6LF5nkw==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.1.tgz",
+      "integrity": "sha512-tYfKpWL56meSJCHS91Ph0+EUThHZOZ8bKuboME4998SF+Kkukp2PhCPdRCvA7tsGUKr9FvSoyIRqJPuImBcBuA==",
       "dependencies": {
         "@digitalbazaar/http-client": "^3.4.1",
         "canonicalize": "^1.0.1",
@@ -13789,12 +13789,12 @@
       "dev": true
     },
     "@think-it-labs/edc-connector-client": {
-      "version": "0.2.0-beta-3",
-      "resolved": "https://registry.npmjs.org/@think-it-labs/edc-connector-client/-/edc-connector-client-0.2.0-beta-3.tgz",
-      "integrity": "sha512-NVLQr/zGQaEWRZHxcVmxjoZgegBknTKNEqsYSS18OUW42tO97+mgpuEUyjtuvdyyQTkYAv/fPH0tIDih8i7XDw==",
+      "version": "0.2.0-beta-5",
+      "resolved": "https://registry.npmjs.org/@think-it-labs/edc-connector-client/-/edc-connector-client-0.2.0-beta-5.tgz",
+      "integrity": "sha512-5mFAqShsXggxAzW3+KXdODns6tHLU4gyKVbeJxddxDcGbX3aHeQsvBsjJOGebEymTJNp0w93I11f5VVvzTHQjw==",
       "requires": {
         "@think-it-labs/typed-error": "^0.3.0",
-        "jsonld": "^8.2.0"
+        "jsonld": "^8.2.1"
       }
     },
     "@think-it-labs/typed-error": {
@@ -17193,9 +17193,9 @@
       }
     },
     "jsonld": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.2.0.tgz",
-      "integrity": "sha512-qHUa9pn3/cdAZw26HY1Jmy9+sHOxaLrveTRWUcrSDx5apTa20bBTe+X4nzI7dlqc+M5GkwQW6RgRdqO6LF5nkw==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.1.tgz",
+      "integrity": "sha512-tYfKpWL56meSJCHS91Ph0+EUThHZOZ8bKuboME4998SF+Kkukp2PhCPdRCvA7tsGUKr9FvSoyIRqJPuImBcBuA==",
       "requires": {
         "@digitalbazaar/http-client": "^3.4.1",
         "canonicalize": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "~13.3.5",
     "@angular/platform-browser-dynamic": "~13.3.5",
     "@angular/router": "~13.3.5",
-    "@think-it-labs/edc-connector-client": "^0.2.0-beta-3",
+    "@think-it-labs/edc-connector-client": "^0.2.0-beta-5",
     "rxjs": "~7.8.1",
     "zone.js": "~0.11.4"
   },

--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.html
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.html
@@ -2,7 +2,7 @@
 
     <mat-form-field class="form-field" color="accent" id="form-field-id">
         <mat-label>Id</mat-label>
-        <input [(ngModel)]="contractDefinition.id" [disabled]="editMode" matInput required>
+        <input [(ngModel)]="contractDefinition['@id']" [disabled]="editMode" matInput required>
     </mat-form-field>
 
     <div>

--- a/src/modules/edc-demo/components/contract-definition-viewer/contract-definition-viewer.component.html
+++ b/src/modules/edc-demo/components/contract-definition-viewer/contract-definition-viewer.component.html
@@ -24,19 +24,19 @@
         <mat-card *ngFor="let contractDefinition of contractDefinitions" class="contract-definition-card">
             <mat-card-header>
                 <mat-icon mat-card-avatar>policy</mat-icon>
-                <mat-card-title>{{contractDefinition['@id']}}</mat-card-title>
+                <mat-card-title>{{contractDefinition.id}}</mat-card-title>
             </mat-card-header>
             <mat-card-content>
                 <mat-list dense>
                     <mat-list-item>
                         <mat-icon mat-list-icon>policy</mat-icon>
                         <div class="policy-name" mat-line>Access policy</div>
-                        <div mat-line>{{contractDefinition['edc:accessPolicyId']}}</div>
+                        <div mat-line>{{contractDefinition.accessPolicyId}}</div>
                     </mat-list-item>
                     <mat-list-item>
                         <mat-icon mat-list-icon>policy</mat-icon>
                         <div class="policy-name" mat-line>Contract policy</div>
-                        <div mat-line>{{contractDefinition['edc:contractPolicyId']}}</div>
+                        <div mat-line>{{contractDefinition.contractPolicyId}}</div>
                     </mat-list-item>
                 </mat-list>
 
@@ -47,24 +47,11 @@
                         </mat-panel-title>
                     </mat-expansion-panel-header>
                     <mat-list dense>
-                        <mat-list-item *ngFor="let criterion of contractDefinition['edc:assetsSelector']">
+                        <mat-list-item *ngFor="let criterion of contractDefinition.assetsSelector">
                             <mat-icon mat-list-icon>check</mat-icon>
-                            <div mat-line>{{criterion['edc:operandLeft']}} {{criterion['edc:operator']}} {{criterion['edc:operandRight']}}</div>
+                            <!-- mandatoryValue method needs to be used because of this bug: https://github.com/Think-iT-Labs/edc-connector-client/issues/94 -->
+                            <div mat-line>{{criterion.mandatoryValue('edc', 'operandLeft')}} {{criterion.mandatoryValue('edc', 'operator')}} {{criterion.mandatoryValue('edc', 'operandRight')}}</div>
                         </mat-list-item>
-                        <!-- <mat-list-item *ngIf="asset.contentType">
-                            <mat-icon mat-list-icon>content_paste</mat-icon>
-                            <div mat-line class="asset-property-name">Content-Type</div>
-                            <div mat-line>{{asset.contentType}}</div>
-                        </mat-list-item>
-                        <mat-list-item *ngFor="let additionalPropertyKey of asset.additionalPropertyKeys">
-                            <mat-icon mat-list-icon>list</mat-icon>
-                            <div mat-line *ngIf="additionalPropertyKey.replace('asset:prop:', '') as name"
-                                class="asset-property-name">
-                                {{name.charAt(0).toUpperCase() + name.slice(1)}}
-                            </div>
-                            <div mat-line title="{{asset.properties[additionalPropertyKey]}}">
-                                {{asset.properties[additionalPropertyKey]}}</div>
-                        </mat-list-item> -->
                     </mat-list>
                 </mat-expansion-panel>
 

--- a/src/modules/mgmt-api-client/api/asset.service.ts
+++ b/src/modules/mgmt-api-client/api/asset.service.ts
@@ -16,7 +16,7 @@ import { HttpResponse, HttpEvent, HttpContext } from '@angular/common/http';
 import { Observable, from }                                        from 'rxjs';
 
 import { EdcConnectorClient } from '@think-it-labs/edc-connector-client';
-import { AssetInput, AssetResponse, IdResponse, QuerySpec } from "../model"
+import { AssetInput, Asset, IdResponse, QuerySpec } from "../model"
 
 @Injectable({
   providedIn: 'root'
@@ -24,7 +24,6 @@ import { AssetInput, AssetResponse, IdResponse, QuerySpec } from "../model"
 export class AssetService {
 
     private assets = this.edcConnectorClient.management.assets;
-    protected basePath = 'http://localhost';
 
     constructor(private edcConnectorClient: EdcConnectorClient) {
     }
@@ -48,9 +47,9 @@ export class AssetService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getAsset(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<AssetResponse>;
-    public getAsset(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<AssetResponse>>;
-    public getAsset(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<AssetResponse>>;
+    public getAsset(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Asset>;
+    public getAsset(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Asset>>;
+    public getAsset(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Asset>>;
     public getAsset(id: string): Observable<any> {
         if (id === null || id === undefined) {
             throw new Error('Required parameter id was null or undefined when calling getAsset.');
@@ -83,9 +82,9 @@ export class AssetService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public requestAssets(querySpecDto?: QuerySpec, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Array<AssetResponse>>;
-    public requestAssets(querySpecDto?: QuerySpec, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Array<AssetResponse>>>;
-    public requestAssets(querySpecDto?: QuerySpec, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Array<AssetResponse>>>;
+    public requestAssets(querySpecDto?: QuerySpec, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Array<Asset>>;
+    public requestAssets(querySpecDto?: QuerySpec, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Array<Asset>>>;
+    public requestAssets(querySpecDto?: QuerySpec, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Array<Asset>>>;
     public requestAssets(querySpecDto?: QuerySpec): Observable<any> {
         return from(this.assets.queryAll(querySpecDto))
     }

--- a/src/modules/mgmt-api-client/api/contractDefinition.service.ts
+++ b/src/modules/mgmt-api-client/api/contractDefinition.service.ts
@@ -11,28 +11,11 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent, HttpParameterCodec, HttpContext
-        }       from '@angular/common/http';
-import { CustomHttpParameterCodec }                          from '../encoder';
-import { Observable }                                        from 'rxjs';
-
-// @ts-ignore
-import { ApiErrorDetail } from '../model/apiErrorDetail';
-// @ts-ignore
-import { ContractDefinitionRequestDto } from '../model/contractDefinitionRequestDto';
-// @ts-ignore
-import { ContractDefinitionResponseDto } from '../model/contractDefinitionResponseDto';
-// @ts-ignore
-import { IdResponseDto } from '../model/idResponseDto';
-// @ts-ignore
-import { QuerySpecDto } from '../model/querySpecDto';
-
-// @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
-
+import { Injectable } from '@angular/core';
+import { HttpResponse, HttpEvent, HttpContext } from '@angular/common/http';
+import { Observable, from } from 'rxjs';
+import { EdcConnectorClient } from '@think-it-labs/edc-connector-client';
+import { ContractDefinitionInput, ContractDefinition, IdResponse, QuerySpec } from "../model"
 
 
 @Injectable({
@@ -40,127 +23,22 @@ import { Configuration }                                     from '../configurat
 })
 export class ContractDefinitionService {
 
-    protected basePath = 'http://localhost';
-    public defaultHeaders = new HttpHeaders();
-    public configuration = new Configuration();
-    public encoder: HttpParameterCodec;
+    private contractDefinitions = this.edcConnectorClient.management.contractDefinitions;
 
-    constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string|string[], @Optional() configuration: Configuration) {
-        if (configuration) {
-            this.configuration = configuration;
-        }
-        if (typeof this.configuration.basePath !== 'string') {
-            if (Array.isArray(basePath) && basePath.length > 0) {
-                basePath = basePath[0];
-            }
-
-            if (typeof basePath !== 'string') {
-                basePath = this.basePath;
-            }
-            this.configuration.basePath = basePath;
-        }
-        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
-    }
-
-
-    // @ts-ignore
-    private addToHttpParams(httpParams: HttpParams, value: any, key?: string): HttpParams {
-        if (typeof value === "object" && value instanceof Date === false) {
-            httpParams = this.addToHttpParamsRecursive(httpParams, value);
-        } else {
-            httpParams = this.addToHttpParamsRecursive(httpParams, value, key);
-        }
-        return httpParams;
-    }
-
-    private addToHttpParamsRecursive(httpParams: HttpParams, value?: any, key?: string): HttpParams {
-        if (value == null) {
-            return httpParams;
-        }
-
-        if (typeof value === "object") {
-            if (Array.isArray(value)) {
-                (value as any[]).forEach( elem => httpParams = this.addToHttpParamsRecursive(httpParams, elem, key));
-            } else if (value instanceof Date) {
-                if (key != null) {
-                    httpParams = httpParams.append(key, (value as Date).toISOString().substr(0, 10));
-                } else {
-                   throw Error("key may not be null if value is Date");
-                }
-            } else {
-                Object.keys(value).forEach( k => httpParams = this.addToHttpParamsRecursive(
-                    httpParams, value[k], key != null ? `${key}.${k}` : k));
-            }
-        } else if (key != null) {
-            httpParams = httpParams.append(key, value);
-        } else {
-            throw Error("key may not be null if value is not object or array");
-        }
-        return httpParams;
+    constructor(private edcConnectorClient: EdcConnectorClient) {
     }
 
     /**
      * Creates a new contract definition
-     * @param contractDefinitionRequestDto
+     * @param input
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public createContractDefinition(contractDefinitionRequestDto?: ContractDefinitionRequestDto, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<IdResponseDto>;
-    public createContractDefinition(contractDefinitionRequestDto?: ContractDefinitionRequestDto, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<IdResponseDto>>;
-    public createContractDefinition(contractDefinitionRequestDto?: ContractDefinitionRequestDto, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<IdResponseDto>>;
-    public createContractDefinition(contractDefinitionRequestDto?: ContractDefinitionRequestDto, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<any> {
-
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'application/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
-        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
-        if (httpContentTypeSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
-        }
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/v2/contractdefinitions`;
-        return this.httpClient.request<IdResponseDto>('post', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                body: contractDefinitionRequestDto,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+    public createContractDefinition(input: ContractDefinitionInput, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<IdResponse>;
+    public createContractDefinition(input: ContractDefinitionInput, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<IdResponse>>;
+    public createContractDefinition(input: ContractDefinitionInput, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<IdResponse>>;
+    public createContractDefinition(input: ContractDefinitionInput): Observable<any> {
+        return from(this.contractDefinitions.create(input));
     }
 
     /**
@@ -172,136 +50,26 @@ export class ContractDefinitionService {
     public deleteContractDefinition(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<any>;
     public deleteContractDefinition(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<any>>;
     public deleteContractDefinition(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<any>>;
-    public deleteContractDefinition(id: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<any> {
-        if (id === null || id === undefined) {
-            throw new Error('Required parameter id was null or undefined when calling deleteContractDefinition.');
-        }
+    public deleteContractDefinition(id: string): Observable<any> {
+      if (id === null || id === undefined) {
+          throw new Error('Required parameter id was null or undefined when calling deleteContractDefinition.');
+      }
 
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'application/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/v2/contractdefinitions/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.request<any>('delete', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+      return from(this.contractDefinitions.delete(id))
     }
 
     /**
      * Returns all contract definitions according to a query
-     * @param offset
-     * @param limit
-     * @param filter
-     * @param sort
-     * @param sortField
+     * @param querySpec
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      * @deprecated
      */
-    public getAllContractDefinitions(offset?: number, limit?: number, filter?: string, sort?: 'ASC' | 'DESC', sortField?: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Array<ContractDefinitionResponseDto>>;
-    public getAllContractDefinitions(offset?: number, limit?: number, filter?: string, sort?: 'ASC' | 'DESC', sortField?: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Array<ContractDefinitionResponseDto>>>;
-    public getAllContractDefinitions(offset?: number, limit?: number, filter?: string, sort?: 'ASC' | 'DESC', sortField?: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Array<ContractDefinitionResponseDto>>>;
-    public getAllContractDefinitions(offset?: number, limit?: number, filter?: string, sort?: 'ASC' | 'DESC', sortField?: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<any> {
-
-        let localVarQueryParameters = new HttpParams({encoder: this.encoder});
-        if (offset !== undefined && offset !== null) {
-          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
-            <any>offset, 'offset');
-        }
-        if (limit !== undefined && limit !== null) {
-          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
-            <any>limit, 'limit');
-        }
-        if (filter !== undefined && filter !== null) {
-          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
-            <any>filter, 'filter');
-        }
-        if (sort !== undefined && sort !== null) {
-          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
-            <any>sort, 'sort');
-        }
-        if (sortField !== undefined && sortField !== null) {
-          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
-            <any>sortField, 'sortField');
-        }
-
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'application/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/v2/contractdefinitions`;
-        return this.httpClient.request<Array<ContractDefinitionResponseDto>>('get', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                params: localVarQueryParameters,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+    public getAllContractDefinitions(querySpec?: QuerySpec, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Array<ContractDefinition>>;
+    public getAllContractDefinitions(querySpec?: QuerySpec, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Array<ContractDefinition>>>;
+    public getAllContractDefinitions(querySpec?: QuerySpec, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Array<ContractDefinition>>>;
+    public getAllContractDefinitions(querySpec?: QuerySpec): Observable<any> {
+        return from(this.contractDefinitions.queryAll(querySpec))
     }
 
     /**
@@ -310,120 +78,28 @@ export class ContractDefinitionService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getContractDefinition(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<ContractDefinitionResponseDto>;
-    public getContractDefinition(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<ContractDefinitionResponseDto>>;
-    public getContractDefinition(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<ContractDefinitionResponseDto>>;
-    public getContractDefinition(id: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<any> {
+    public getContractDefinition(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<ContractDefinition>;
+    public getContractDefinition(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<ContractDefinition>>;
+    public getContractDefinition(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<ContractDefinition>>;
+    public getContractDefinition(id: string): Observable<any> {
         if (id === null || id === undefined) {
             throw new Error('Required parameter id was null or undefined when calling getContractDefinition.');
         }
 
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'application/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/v2/contractdefinitions/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}`;
-        return this.httpClient.request<ContractDefinitionResponseDto>('get', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        return from(this.contractDefinitions.get(id))
     }
 
     /**
      * Returns all contract definitions according to a query
-     * @param querySpecDto
+     * @param querySpec
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public queryAllContractDefinitions(querySpecDto?: QuerySpecDto, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Array<ContractDefinitionResponseDto>>;
-    public queryAllContractDefinitions(querySpecDto?: QuerySpecDto, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Array<ContractDefinitionResponseDto>>>;
-    public queryAllContractDefinitions(querySpecDto?: QuerySpecDto, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Array<ContractDefinitionResponseDto>>>;
-    public queryAllContractDefinitions(querySpecDto?: QuerySpecDto, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<any> {
-
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'application/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
-        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
-        if (httpContentTypeSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
-        }
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/v2/contractdefinitions/request`;
-        return this.httpClient.request<Array<ContractDefinitionResponseDto>>('post', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                body: querySpecDto,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+    public queryAllContractDefinitions(querySpec?: QuerySpec, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<Array<ContractDefinition>>;
+    public queryAllContractDefinitions(querySpec?: QuerySpec, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpResponse<Array<ContractDefinition>>>;
+    public queryAllContractDefinitions(querySpec?: QuerySpec, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext}): Observable<HttpEvent<Array<ContractDefinition>>>;
+    public queryAllContractDefinitions(querySpec?: QuerySpec): Observable<any> {
+        return from(this.contractDefinitions.queryAll(querySpec))
     }
 
 }

--- a/src/modules/mgmt-api-client/model/edc-connector-entities.ts
+++ b/src/modules/mgmt-api-client/model/edc-connector-entities.ts
@@ -4,7 +4,6 @@ export type {
   ApiErrorDetail,
   Asset,
   AssetInput,
-  AssetResponse,
   Catalog,
   CatalogRequest,
   Constraint,
@@ -32,5 +31,4 @@ export type {
   TransferProcess,
   TransferProcessInput,
   TransferProcessResponse,
-  TransferType,
 } from "@think-it-labs/edc-connector-client";

--- a/src/modules/mgmt-api-client/model/index.ts
+++ b/src/modules/mgmt-api-client/model/index.ts
@@ -1,2 +1,1 @@
 export * from "./edc-connector-entities";
-


### PR DESCRIPTION
## What this PR changes/adds

Use EDC-connector-client for `ContractDefinition

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- bumped edc-connector-client to beta5

## Linked Issue(s)

Closes #55 
but also
Closes #74

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
