### PR TITLE
fix: Set Correct Value for operandLeft in assetSelector in ContractDefinition

### DIFF
--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
@@ -60,7 +60,7 @@ export class ContractDefinitionEditorDialog implements OnInit {
 
     const ids = this.assets.map(asset => asset.id);
     this.contractDefinition.assetsSelector = [...this.contractDefinition.assetsSelector, {
-      operandLeft: 'asset:prop:id',
+      operandLeft: 'https://w3id.org/edc/v0.0.1/ns/id',
       operator: 'in',
       operandRight: ids,
     }];


### PR DESCRIPTION
## What this PR changes/adds

BugFix of the ContractDefinition AssetSelector.

## Why it does that

BugFix

## Linked Issue(s)

Closes #92
