### PR TITLE
fix: add lastUpdated Column in Transfer History (#142)

### DIFF
--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -32,7 +32,7 @@
 
           <ng-container matColumnDef="lastUpdated">
             <th mat-header-cell *matHeaderCellDef scope="col">Last updated</th>
-            <td mat-cell *matCellDef="let item">{{asDate(item.stateTimestamp)}}</td>
+            <td mat-cell *matCellDef="let item">{{asDate(item.mandatoryValue('edc', 'stateTimestamp'))}}</td>
           </ng-container>        
 
           <ng-container matColumnDef="connectorId">

--- a/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
+++ b/src/modules/edc-demo/components/transfer-history/transfer-history-viewer.component.html
@@ -30,6 +30,11 @@
               <td mat-cell *matCellDef="let item">{{item.state}}</td>
           </ng-container>
 
+          <ng-container matColumnDef="lastUpdated">
+            <th mat-header-cell *matHeaderCellDef scope="col">Last updated</th>
+            <td mat-cell *matCellDef="let item">{{asDate(item.stateTimestamp)}}</td>
+          </ng-container>        
+
           <ng-container matColumnDef="connectorId">
               <th mat-header-cell *matHeaderCellDef scope="col">ConnectorId</th>
               <td mat-cell *matCellDef="let item">{{item.connectorId}}</td>


### PR DESCRIPTION
## What this PR changes/adds

Add lastUpdated column in Transfer History page

## Why it does that

lastUpdated column was removed by mistake in previous commit 27f3b34176e4a66d7d613b50d366220e7ad4da89 .

## Linked Issue(s)

Closes #142