### PR TITLE
fix: #217 fix typo in policy property names

### DIFF
--- a/src/modules/edc-demo/services/catalog-browser.service.ts
+++ b/src/modules/edc-demo/services/catalog-browser.service.ts
@@ -64,9 +64,9 @@ export class CatalogBrowserService {
             "uid": hasPolicy["@id"],
             "assignee": hasPolicy["assignee"],
             "assigner": hasPolicy["assigner"],
-            "obligation": hasPolicy["odrl:obligations"],
-            "permission": hasPolicy["odrl:permissions"],
-            "prohibition": hasPolicy["odrl:prohibitions"],
+            "obligation": hasPolicy["odrl:obligation"],
+            "permission": hasPolicy["odrl:permission"],
+            "prohibition": hasPolicy["odrl:prohibition"],
             "target": hasPolicy["odrl:target"]
           };
 


### PR DESCRIPTION
## What this PR changes/adds

Fix typo in policy property names.

## Why it does that

This is a fix proposal for the infinit loop in contract negotiation due to missing policy permissions.

## Linked Issue(s)

Closes #217 