### PR TITLE
fix: update URL syntax in cypress.config.ts 

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     experimentalStudio: true
   },
   env: {
-    consumerUrl: 'http//localhost:18080',
-    providerUrl: 'http//localhost:28080',
+    consumerUrl: 'http://localhost:18080',
+    providerUrl: 'http://localhost:28080',
   },
 })

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -15,7 +15,7 @@ describe('end-to-end', () => {
     const id = uuid()
     const name = `asset-${id}`
 
-    cy.get('[href="/my-assets"]').as('assets-menu-item').click();
+    cy.get('[href="/my-assets"]').first().as('assets-menu-item').click();
     cy.get('#mat-input-0').as('asset-filter')
     cy.get('.container').contains('Create asset').as('open-new-asset-dialog').click();
     cy.get('#mat-input-1').as('asset-id-field').clear();


### PR DESCRIPTION
## What this PR changes/adds

* The consumer and provider URLs in [cypress.config.ts](https://github.com/eclipse-edc/DataDashboard/blob/main/cypress.config.ts) file have been updated with right syntax. 

* In [spec.cy.js](https://github.com/eclipse-edc/DataDashboard/blob/main/cypress/e2e/spec.cy.js) file, the test - ```cy.get('[href="/my-assets"]').as('assets-menu-item').click();```
has been replaced with, ```cy.get('[href="/my-assets"]').first().as('assets-menu-item').click();```


## Why it does that

* In [spec.cy.js](https://github.com/eclipse-edc/DataDashboard/blob/main/cypress/e2e/spec.cy.js) file the cypress tests aims to visit two URLs - `consumerUrl` and `providerUrl`.  These two URLs are configured in [cypress.config.ts](https://github.com/eclipse-edc/DataDashboard/blob/main/cypress.config.ts) file as `consumerUrl: 'http//localhost:18080'`, and `providerUrl: 'http//localhost:28080'`, which do not follow the generic URL syntax and ends up showing unexpected behavior. Therefore, these two URLs has been updated with right syntax.

* In the `introduction` page of the DataDashboard there are two links with the tag `href="/my-assets"`. The test ```cy.get('[href="/my-assets"]').as('assets-menu-item').click();``` can not get executed successfully as cypress finds multiple elements of such kind. 
In this PR, `cy.get('[href="/my-assets"]')` has been chained with the `first()` command so it gets the first element of such type within the set of elements.




## Linked Issue(s)

Closes #248


