### PR TITLE
fix: apply healthcheck interval on app load

### DIFF
--- a/projects/dashboard-core/src/lib/services/edc-client.service.ts
+++ b/projects/dashboard-core/src/lib/services/edc-client.service.ts
@@ -108,6 +108,8 @@ export class EdcClientService implements OnDestroy {
    */
   public setHealthCheckInterval(interval: number): void {
     this.healthCheckInterval = interval;
+    this.stopHealthCheckJob();
+    this.startHealthCheckJob();
   }
 
   private runHealthCheck(edcConfig?: EdcConfig): void {


### PR DESCRIPTION
## What this PR changes/adds

Fix when a new app-config is loaded the healthcheck interval was not set right away.
