### PR TITLE
feat: app title config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ before changing this file.
 Beside the connector configuration, there is some application configuration. The configuration is loaded from `public/config/app-config.json`.
 The [app-config.json](public/config/app-config.json) in this repository contains the default configuration.
 The following application config values exist:
+- `appTitle` (string): Set the name of the application in the header area.<br>__Default__: EDC Dashboard
 - `menuItems` ([MenuItem](projects/dashboard-core/src/lib/models/menu-item.ts) Array): Configure the menu items (views) of the dashboard. Set the icon, text, router path and view description (for the home view) for each item.
 - `healthCheckIntervalSeconds` (number): Sets the interval in seconds to check if the connection to the current connector is still established.<br>__Default__: `30`
 - `enableUserConfig` (boolean): If enabled, the user has the ability to add connectors within the dashboard.

--- a/projects/dashboard-core/src/lib/dashboard-app/dashboard-app.component.html
+++ b/projects/dashboard-core/src/lib/dashboard-app/dashboard-app.component.html
@@ -29,20 +29,21 @@
 <div class="box-border flex h-screen w-screen max-h-screen max-w-screen flex-col bg-base-100 pt-4">
   <div class="navbar min-h-fit px-4 mx-4 max-w-[calc(100%-2rem)] rounded-2xl bg-neutral text-neutral-content shadow-xl">
     <div class="navbar-start">
-      <div
+      <button
         class="btn btn-lg btn-circle btn-ghost hover:text-primary-content hover:bg-primary border-none"
         role="button"
         (click)="stateService.toggleMenuOpen()"
+        [disabled]="((appConfig | async)?.menuItems)!.length < 2"
       >
         @if (stateService.isMenuOpen$ | async) {
           <span class="material-symbols-rounded h7 w-7 !text-[1.75rem]">menu_open</span>
         } @else {
           <span class="material-symbols-rounded h7 w-7 !text-[1.75rem]">menu</span>
         }
-      </div>
+      </button>
     </div>
     <div class="navbar-center">
-      <div class="text-lg">EDC Dashboard</div>
+      <div class="text-lg">{{ (appConfig | async)?.appTitle ?? 'EDC Dashboard' }}</div>
       @if ((stateService.edcConfigs$ | async) && (stateService.currentEdcConfig$ | async)) {
         <div class="dropdown dropdown-center dropdown-hover ml-5">
           <div
@@ -172,29 +173,35 @@
   </div>
 
   <div class="box-border py-4 pl-4 flex flex-auto overflow-auto">
-    <ul
-      class="menu flex-nowrap shrink-0 h-full rounded-2xl bg-neutral text-neutral-content shadow-xl [&_li>a]:px-4 overflow-auto"
-    >
-      <ng-container *ngFor="let item of menuItems">
-        <button
-          class="btn btn-lg btn-ghost justify-start shadow-none hover:text-primary-content hover:bg-primary border-none transition-none"
-          routerLink="{{ item.routerPath }}"
-          routerLinkActive="text-primary"
-        >
-          <span class="material-symbols-rounded h-7 w-7 !text-[1.75rem]">{{ item.materialSymbol }}</span>
-          @if (stateService.isMenuOpen$ | async) {
-            <span class="text-sm">{{ item.text }}</span>
+    @if (((appConfig | async)?.menuItems)!.length > 1) {
+      <ul
+        class="menu flex-nowrap shrink-0 h-full rounded-2xl bg-neutral text-neutral-content shadow-xl [&_li>a]:px-4 overflow-auto"
+      >
+        <ng-container *ngFor="let item of (appConfig | async)?.menuItems">
+          <button
+            class="btn btn-lg btn-ghost justify-start shadow-none hover:text-primary-content hover:bg-primary border-none transition-none"
+            routerLink="{{ item.routerPath }}"
+            routerLinkActive="text-primary"
+          >
+            <span class="material-symbols-rounded h-7 w-7 !text-[1.75rem]">{{ item.materialSymbol }}</span>
+            @if (stateService.isMenuOpen$ | async) {
+              <span class="text-sm">{{ item.text }}</span>
+            }
+          </button>
+          @if (item.divider) {
+            <div
+              class="divider after:bg-neutral-content before:bg-neutral-content after:opacity-15 before:opacity-15 my-0 px-2"
+            ></div>
           }
-        </button>
-        @if (item.divider) {
-          <div
-            class="divider after:bg-neutral-content before:bg-neutral-content after:opacity-15 before:opacity-15 my-0 px-2"
-          ></div>
-        }
-      </ng-container>
-    </ul>
+        </ng-container>
+      </ul>
+    }
 
-    <div id="router-content" class="px-4 box-border w-full overflow-auto">
+    <div
+      id="router-content"
+      class="px-4 box-border w-full"
+      [ngClass]="((appConfig | async)?.menuItems)!.length > 1 ? '' : 'pl-0'"
+    >
       <router-outlet></router-outlet>
     </div>
   </div>

--- a/projects/dashboard-core/src/lib/dashboard-app/dashboard-app.component.ts
+++ b/projects/dashboard-core/src/lib/dashboard-app/dashboard-app.component.ts
@@ -22,7 +22,6 @@ import { ModalAndAlertService } from '../services/modal-and-alert.service';
 import { DeleteConfirmComponent } from '../common/deletion-confirm/deletion-confirm.component';
 import { ConnectorConfigFormComponent } from '../common/connector-config-form/connector-config-form.component';
 import { AppConfig } from '../models/app-config';
-import { MenuItem } from '../models/menu-item';
 
 @Component({
   selector: 'lib-dashboard-app',
@@ -38,8 +37,6 @@ export class DashboardAppComponent implements AfterViewInit {
 
   @ViewChild('dashboardModal', { read: ViewContainerRef, static: true }) modal!: ViewContainerRef;
   @ViewChild('dashboardAlert', { read: ViewContainerRef, static: true }) alert!: ViewContainerRef;
-
-  public menuItems: MenuItem[] = [];
 
   constructor(
     public stateService: DashboardStateService,
@@ -61,7 +58,6 @@ export class DashboardAppComponent implements AfterViewInit {
       );
       return;
     } else {
-      this.menuItems = appConfig.menuItems;
       this.stateService.setAppConfig(appConfig);
     }
 

--- a/projects/dashboard-core/src/lib/models/app-config.ts
+++ b/projects/dashboard-core/src/lib/models/app-config.ts
@@ -18,4 +18,5 @@ export interface AppConfig {
   menuItems: MenuItem[];
   healthCheckIntervalSeconds?: number; // Default: 30
   enableUserConfig?: boolean; // Default: true
+  appTitle?: string; // Default 'EDC Dashboard'
 }

--- a/projects/dashboard-core/src/lib/services/edc-client.service.ts
+++ b/projects/dashboard-core/src/lib/services/edc-client.service.ts
@@ -108,6 +108,8 @@ export class EdcClientService implements OnDestroy {
    */
   public setHealthCheckInterval(interval: number): void {
     this.healthCheckInterval = interval;
+    this.stopHealthCheckJob();
+    this.startHealthCheckJob();
   }
 
   private runHealthCheck(edcConfig?: EdcConfig): void {


### PR DESCRIPTION
## What this PR changes/adds

- Fix health check not reconfigured on connector selection.
- Add native html close event callback to modal service.
- Add title to the app config file.
- Do not display menu on the left side, if only one menu item is defined.

## Why it does that

Improve customizability.


## Linked Issue(s)

Closes #276 
